### PR TITLE
update docker compose file to adjust watchtower oversight

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     env_file: env/auth.env
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
+      - "com.centurylinklabs.watchtower.enable=false"
     restart: unless-stopped
 
   cloudflared:


### PR DESCRIPTION
The auth service does not have a container created, instead it is built locally using go build. This causes watchtower difficulties as it can't find a container at docker.io