### PR TITLE
update searxng relating configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ and passwords. Do not check them into source control.*
 
 Make this change to your searxng environment file [env/searxng.env](http://github.com/iamobservable/open-webui-starter/blob/main/env/searxng.example#L3). The link provided will lead you to the github repository to read about it.
 
+### Update and uncomment SEARXNG_BASE_URL
+
+Update the [env/searxng.env](http://github.com/iamobservable/open-webui-starter/blob/main/env/searxng.example#L4) with the domain name you will be using and uncomment the line by removing the # from the beginning. The link provided will lead you to the github repository to read about it.
+
 ### Add a unique WEBUI_SECRET_KEY to your environment files
 
 Make this change to your auth environment file [env/auth.env](http://github.com/iamobservable/open-webui-starter/blob/main/env/auth.example#L2). The link provided will lead you to the github repository to read about it.

--- a/conf/searxng/settings.yml.example
+++ b/conf/searxng/settings.yml.example
@@ -85,6 +85,7 @@ server:
   bind_address: "127.0.0.1"
   # public URL of the instance, to ensure correct inbound links. Is overwritten
   # by ${SEARXNG_URL}.
+  ### BEWARE... THE PREVIOUS IS INCORRECT AND REQUIRES THE USE OF SEARXNG_BASE_URL
   base_url: / # "http://example.com/location"
   # rate limit the number of request on the instance, block some bots.
   # Is overwritten by ${SEARXNG_LIMITER}

--- a/env/searxng.example
+++ b/env/searxng.example
@@ -1,3 +1,4 @@
-SEARXNG_HOST=localhost:8080/
+#SEARXNG_HOST=localhost:8080/
 SEARXNG_REDIS_URL=redis://redis:6379/1
 SEARXNG_SECRET=YOUR-SECRET-KEY
+#SEARXNG_BASE_URL=https://<domain-name/searxng


### PR DESCRIPTION
- note in the settings that SEARXNG_URL is not actually a useful environment variable, but instead SEARXNG_BASE_URL is used. Might send a PR to the searxng team, but for now this should suffice for this repo.
- update searxng env example with correct variable name
- update readme to mention making the change during setup