### PR TITLE
Handle nginx redirects with relative paths

### DIFF
--- a/conf/nginx/conf.d/default.example
+++ b/conf/nginx/conf.d/default.example
@@ -23,6 +23,8 @@ server {
   listen 80;
   server_name <domain-name>;
 
+  absolute_redirect off;
+
   location ~ ^/(docs|redis|searxng) {
     auth_request /auth-server/validate;
     auth_request_set $auth_status $upstream_status;


### PR DESCRIPTION
Nginx was not respecting redirects with a port included. Uses relative paths on redirection fixes this issue.