### PR TITLE
Fix reference to start.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 mkdir -p $HOME/bin
-curl -s https://raw.githubusercontent.com/iamobservable/open-webui-starter/feature/iamobservable/64-convert-project-script-to-installable/starter.sh > $HOME/bin/starter
+curl -s https://raw.githubusercontent.com/iamobservable/open-webui-starter/refs/heads/main/starter.sh > $HOME/bin/starter
 chmod +x $HOME/bin/starter
 
 echo "starter successfully installed in $HOME/bin"


### PR DESCRIPTION
A reference to the original feature branch was used instead of the correct reference to main.